### PR TITLE
Override APIRequestFailed.__str__ to exclude request params

### DIFF
--- a/khl/requester.py
+++ b/khl/requester.py
@@ -74,6 +74,12 @@ class HTTPRequester:
         return ret
 
     class APIRequestFailed(Exception):
+        """
+        Raised when khl.py received non-zero error code from remote server. 
+        By default, params (request body) is not included when calling __str__ on it, to avoid leaking credential 
+        into logs; if request body is needed for debug purpose, consider explicitly catching this exception and 
+        call repr(...) with the exception instance.
+        """
 
         def __init__(self, method, route, params, err_code, err_message):
             self.method = method
@@ -81,3 +87,6 @@ class HTTPRequester:
             self.params = params
             self.err_code = err_code
             self.err_message = err_message
+        
+        def __str__(self):
+            return f"Requesting '{self.method} {self.route}' failed with {self.err_code}: {self.err_message}"


### PR DESCRIPTION
当前代码中，当 `HTTPRequester.request` 抛出 `HTTPRequester.APIRequestFailed` 异常时，会连带打印完整的 request body 到日志/stdout 中，而这个 request body 包含了 header，header 中又有包含了 credential 的 `Authorization` 字段，直接输出有可能会让用户在复制日志时不慎把 credential 泄漏出去。
这个 PR 通过覆写 `HTTPRequester.APIRequestFailed` 的 `__str__` 来缓解这一问题：新的 `__str__` 会以类似下面这样的方式表示 `HTTPRequester.APIRequestFailed`：

```
Requesting 'GET https://www.kaiheila.cn/api/v3/foo' failed with 404: Not found
```

有需要完整 request body 的开发者仍然可以主动捕获 `HTTPRequester.APIRequestFailed` 然后使用 `repr(...)`。

同时本 PR 为 `HTTPRequester.APIRequestFailed` 添加了 docstring，内容基本同上。