### PR TITLE
fix(bot): register regular message handler twice

### DIFF
--- a/khl/bot/bot.py
+++ b/khl/bot/bot.py
@@ -56,7 +56,9 @@ class Bot(AsyncRunnable):
         if not token and not cert:
             raise ValueError('require token or cert')
         self._init_client(cert or Cert(token=token), client, gate, out, compress, port, route)
-        self.client.register(MessageTypes.TEXT, self._make_msg_handler())
+        msg_handler=self._make_msg_handler()
+        self.client.register(MessageTypes.TEXT, msg_handler)
+        self.client.register(MessageTypes.KMD, msg_handler)
         self.client.register(MessageTypes.SYS, self._make_event_handler())
 
         self.command = CommandManager()


### PR DESCRIPTION
在本 PR 发出的几小时前，开黑啦已经为部分客户端发布了更新，令 KMarkdown 消息成为默认消息的发布格式，进而导致现有机器人无法响应通过这些客户端发出的消息。截至 commit 2796754 推送时，已知更新后的开黑啦 iOS 客户端默认发布的消息即为 KMarkdown 消息。

这个 PR 通过将 Bot 注册的默认消息 handler 重复注册一次来缓解这一问题：多注册的一次用于订阅 KMarkdown 消息。

*时间比较紧迫（指差不多要睡了），所以没有来得及测试，还请见谅。*