### PR TITLE
修改参数分割原则，支持带空格前缀

### DIFF
--- a/khl/command/lexer.py
+++ b/khl/command/lexer.py
@@ -60,11 +60,11 @@ class DefaultLexer(Lexer):
 
         for prefix in matched_prefixes:
             try:
-                arg_list = shlex.split(msg.content)
+                arg_list = shlex.split(msg.content[len(prefix):])
             except Exception:
                 raise DefaultLexer.MalformedContent(msg)
             # check if trigger exists
-            if arg_list[0][len(prefix):] not in self.triggers:
+            if arg_list[0] not in self.triggers:
                 raise Lexer.NotMatched(msg)
             return arg_list[1:]  # arg_list[0] is trigger
 


### PR DESCRIPTION
原逻辑如果前缀自带空格，比如使用单词作为前缀，会导致命令被切分成参数，无法识别命令。