### PR TITLE
feat(_types): [added|deleted|updated]_emoji

### DIFF
--- a/khl/_types.py
+++ b/khl/_types.py
@@ -44,6 +44,7 @@ class EventTypes(Enum):
     DELETED_REACTION = 'deleted_reaction'
     UPDATED_MESSAGE = 'updated_message'
     DELETED_MESSAGE = 'deleted_message'
+    MESSAGE_UPDATED = 'message_updated'
 
     PRIVATE_ADDED_REACTION = 'private_added_reaction'
     PRIVATE_DELETED_REACTION = 'private_deleted_reaction'

--- a/khl/_types.py
+++ b/khl/_types.py
@@ -79,6 +79,10 @@ class EventTypes(Enum):
     PINNED_MESSAGE = 'pinned_message'
     UNPINNED_MESSAGE = 'unpinned_message'
 
+    ADDED_EMOJI = 'added_emoji'
+    DELETED_EMOJI = 'deleted_emoji'
+    UPDATED_EMOJI = 'updated_emoji'
+
 
 class GuildMuteTypes(IntEnum):
     """


### PR DESCRIPTION
根据 KOOK 里的反馈，这三个类型的系统消息在一周前或更早时间出现，用途暂时不明确，有人猜测是 9 月初推出的道具系统（截至本 PR 创建时只有「哧溜」对外发放过）。

有鉴于 `EventTypes` 是一个 `Enum`，若没有显式定义就尝试把 `added_emoji` 等转换成 `EventTypes` 会报错（例：`ValueError: 'added_emoji' is not a valid EventTypes`）。本 PR 尝试通过添加三种新系统消息类型在 `EventTypes` 的定义来解决这个问题。

此外，还有一个一劳永逸但工作量大的解决方法：在所有使用 `EventTypes` 的地方都改为使用 `Union[EventTypes, str]`，这样如果在未来出现了新消息，我们可以直接使用 raw str 来表示其类型，从而避免出错。有鉴于这个方案可能有潜在的副作用，这里并没有直接采用这个方案，仅在此列出供讨论。