### PR TITLE
修正创建分组时导致的错误

### DIFF
--- a/khl/guild.py
+++ b/khl/guild.py
@@ -310,6 +310,7 @@ class Guild(LazyLoadable, Requestable):
         if type is not None:
             if type == ChannelTypes.CATEGORY:
                 params['is_category'] = 1
+                return ChannelCategory(**(await self.gate.exec_req(api.Channel.create(**params))), _gate_=self.gate)
             else:
                 params['type'] = type.value
         if category:


### PR DESCRIPTION
# 问题原因

创建类别为 分组 的频道时, 方法调用 [create_channel](https://github.com/TWT233/khl.py/blob/main/khl/guild.py#L300)  
```python
if type is not None:
            if type == ChannelTypes.CATEGORY:
                params['is_category'] = 1
                       ^^^^^^^^^^^^^^ 问题的第一步出现于此处, 未对 params['type'] 赋值 且为未做其他处理
            else:
                params['type'] = type.value
        if category:
            params['parent_id'] = unpack_id(category)
        if limit_amount:
            params['limit_amount'] = limit_amount
        if voice_quality:
            params['voice_quality'] = voice_quality
        return public_channel_factory(self.gate, **(await self.gate.exec_req(api.Channel.create(**params))))
                     ^^^^^^^^随后传递
```
接下来调用 [public_channel_factory](https://github.com/TWT233/khl.py/blob/main/khl/channel.py#L200)  
```python
def public_channel_factory(_gate_: Gateway, **kwargs) -> Optional[PublicChannel]:
    """factory function to build a channel object"""
    kwargs['type'] = kwargs['type'] if isinstance(kwargs['type'], ChannelTypes) else ChannelTypes(kwargs['type'])
                                                         此处将 kwargs['type'] 赋值为 0 ^^^^^^^^^^^
    if kwargs['type'] == ChannelTypes.TEXT:
        return PublicTextChannel(**kwargs, _gate_=_gate_)
    if kwargs['type'] == ChannelTypes.VOICE:
        return PublicVoiceChannel(**kwargs, _gate_=_gate_)
    raise ValueError(f'unsupported channel type: {kwargs["type"]}: {kwargs}')
              ^^^^^^^^^ 抛出错误
```
此处 `kwargs['type']` 为 `0` 故直接触发 `raise ValueError(f'unsupported channel type: {kwargs["type"]}: {kwargs}')`

# 问题复现
```python
msg.ctx.guild.create_channel("分类", type=ChannelTypes.CATEGORY)
```

# 修复方式
https://github.com/TWT233/khl.py/pull/167/files#r1032783977