### PR TITLE
feat(channel): allow public_channel_factory to create a category

### DIFF
--- a/khl/channel.py
+++ b/khl/channel.py
@@ -168,6 +168,8 @@ def public_channel_factory(_gate_: Gateway, **kwargs) -> Union[PublicTextChannel
         return PublicTextChannel(**kwargs, _gate_=_gate_)
     if kwargs['type'] == ChannelTypes.VOICE:
         return PublicVoiceChannel(**kwargs, _gate_=_gate_)
+    if kwargs['type'] == ChannelTypes.CATEGORY:
+        return PublicChannel(**kwargs, _gate_=_gate_)
     raise ValueError(f'unsupported channel type: {kwargs["type"]}: {kwargs}')
 
 


### PR DESCRIPTION
This commit would allow the following construct to work:

```python
async def foo(msg: Message):
    new_category = await msg.ctx.guild.create_channel('Dummy Category', ChannelTypes.CATEGORY)
```