### PR TITLE
fix(requester): ClientSession initialized outside asynchrony when using task to run bot

### DIFF
--- a/khl/requester.py
+++ b/khl/requester.py
@@ -20,7 +20,8 @@ class HTTPRequester:
         self._cs: Union[ClientSession, None] = None
 
     def __del__(self):
-        asyncio.get_event_loop().run_until_complete(self._cs.close())
+        if self._cs is not None:
+            asyncio.get_event_loop().run_until_complete(self._cs.close())
 
     async def request(self, method: str, route: str, **params) -> Union[dict, list, bytes]:
         """wrap raw request, fill authorization, handle & extract response"""

--- a/khl/requester.py
+++ b/khl/requester.py
@@ -17,7 +17,7 @@ class HTTPRequester:
 
     def __init__(self, cert: Cert):
         self._cert = cert
-        self._cs: ClientSession = ClientSession()
+        self._cs: Union[ClientSession, None] = None
 
     def __del__(self):
         asyncio.get_event_loop().run_until_complete(self._cs.close())
@@ -29,6 +29,8 @@ class HTTPRequester:
 
         log.debug(f'{method} {route}: req: {params}')  # token is excluded
         headers['Authorization'] = f'Bot {self._cert.token}'
+        if self._cs is None:
+            self._cs = ClientSession()
         async with self._cs.request(method, f'{API}/{route}', **params) as res:
             if res.content_type == 'application/json':
                 rsp = await res.json()

--- a/khl/requester.py
+++ b/khl/requester.py
@@ -30,7 +30,7 @@ class HTTPRequester:
 
         log.debug(f'{method} {route}: req: {params}')  # token is excluded
         headers['Authorization'] = f'Bot {self._cert.token}'
-        if self._cs is None:
+        if self._cs is None:  # lazy init
             self._cs = ClientSession()
         async with self._cs.request(method, f'{API}/{route}', **params) as res:
             if res.content_type == 'application/json':


### PR DESCRIPTION
修复了当使用 asyncio 的 task 去启动机器人时发生的 ClientSession 在异步环境外初始化的问题
Timeout context manager should be used inside a task
![image](https://user-images.githubusercontent.com/20784591/209438356-199dd873-6977-49ba-9d67-dd333776c345.png)
