### PR TITLE
fix(card): force header module to use plain text type

### DIFF
--- a/khl/card/module.py
+++ b/khl/card/module.py
@@ -21,7 +21,8 @@ class Module:
         def __init__(self, text: Union[Element.Text, str] = ''):
             if isinstance(text, str):
                 text = Element.Text(text)
-            self._text = text
+            # Force header to use plain because KOOK right now only supports using plain in header
+            self._text = Element.Text(text.content, Types.Text.PLAIN, text.emoji)
             super().__init__(Types.Theme.NA, Types.Size.NA)
 
         @property


### PR DESCRIPTION
根据 KOOK 的文档：

> 标题模块只能支持展示标准文本（text），突出标题样式。

实际使用中，若直接在构造 `Moulde.Header` 对象时使用类型为 `Types.Text.KMD` 的 `Element.Text` 对象，如此生成的卡片消息最终会导致远端服务器报错。

因此本 PR 尝试通过复制一份 `Element.Text` 对象，并强制指定类型为 `Types.Text.PLAIN` 来满足这一约束。