### PR TITLE
 feat: add simple RabbitMQ support

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
-        pip install --upgrade aiohttp pycryptodomex apscheduler
+        pip install --upgrade aiohttp pycryptodomex apscheduler aio_pika
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/khl/__init__.py
+++ b/khl/__init__.py
@@ -17,7 +17,8 @@ from ._types import (
     FriendTypes
 )
 from .cert import Cert
-from .receiver import Receiver, WebhookReceiver, WebsocketReceiver
+from .rabbitmq import RabbitMQ, RabbitMQProducer
+from .receiver import Receiver, WebhookReceiver, WebsocketReceiver, RabbitMQReceiver
 from .requester import HTTPRequester
 from .gateway import Gateway, Requestable
 from .client import Client

--- a/khl/cert.py
+++ b/khl/cert.py
@@ -29,8 +29,12 @@ class Cert:
         """
         webhook cert
         """
-
-    def __init__(self, *, type: Types = Types.NOTSET, token: str, verify_token: str = '', encrypt_key: str = ''):
+        RABBITMQ = "rabbitmq"
+        """
+        rabbitmq cert
+        """
+    def __init__(self, *, type: Types = Types.NOTSET, token: str, verify_token: str = '', encrypt_key: str = '',
+                 is_rabbitmq_receiver: bool = False):
         """
         all fields from bot config panel
         """
@@ -39,6 +43,8 @@ class Cert:
         else:
             if verify_token:
                 self.type = self.Types.WEBHOOK
+            elif is_rabbitmq_receiver:
+                self.type = self.Types.RABBITMQ
             else:
                 self.type = self.Types.WEBSOCKET
         self.token = token

--- a/khl/rabbitmq.py
+++ b/khl/rabbitmq.py
@@ -1,0 +1,141 @@
+import asyncio
+import hashlib
+import json
+import logging
+import zlib
+
+import aio_pika
+from Cryptodome.Cipher import AES
+from Cryptodome.Util import Padding
+from aio_pika.abc import AbstractRobustConnection, AbstractRobustChannel, AbstractExchange, AbstractRobustQueue
+
+from .interface import AsyncRunnable
+
+log = logging.getLogger(__name__)
+
+
+class RabbitMQ:
+    """rabbitmq configurate/init/connect/encrypt/decrypt/encode/decode"""
+
+    _connection: AbstractRobustConnection = None
+    _channel: AbstractRobustChannel = None
+    _queue: AbstractRobustQueue = None
+    _exchange: AbstractExchange = None
+
+    def __init__(self, login: str, password: str, host: str = '127.0.0.1', port: int = 5672, queue: str = 'kook',
+                 qos: int = 10, heartbeat: int = 30, key: str = '', key_digits: int = 16, is_producer: bool = False):
+        self._host = host
+        self._port = port
+        self.queue = queue
+        self.qos = qos
+        self._heartbeat = heartbeat
+        self._login = login
+        self._password = password
+        self._key = key
+        self._key_digits = key_digits
+        self.is_producer = is_producer
+
+        # check aes is 128, 192 or 256
+        if key_digits not in AES.key_size:
+            raise ValueError(f'rabbitmq key_digits: {key_digits} not in {AES.key_size}')
+        if key != '':
+            key_encoded = key.encode('utf-8').ljust(key_digits, b'\x00')
+        else:
+            # if rabbitmq_key is not defined, use sha256 to generate one
+            key_encoded = hashlib.sha256(f'{login}:{password}'.encode('utf-8')).digest()
+
+        # make sure key digits is right
+        self._aes_key = key_encoded[:key_digits]
+
+    def decrypt(self, data: bytes) -> bytes:
+        """ decrypt data
+
+        :param data: encrypted byte array
+        :return: decrypted byte array
+        """
+        decipher = AES.new(self._aes_key, AES.MODE_CBC, iv=data[:16])
+        data = decipher.decrypt(data[16:])
+        data = Padding.unpad(data, 16)
+        return data
+
+    def encrypt(self, data: bytes) -> bytes:
+        """ encrypt data
+
+        :param data: byte array
+        :return: encrypted byte array
+        """
+        data = Padding.pad(data, 16)
+        cipher = AES.new(self._aes_key, AES.MODE_CBC)
+        data = cipher.encrypt(data)
+        return cipher.iv + data
+
+    def decode(self, data: bytes, compress: bool) -> dict:
+        """decode raw rabbitmq data into plaintext data"""
+        data = self.decrypt(data)
+        if compress:
+            data = zlib.decompress(data)
+        return json.loads(str(data, encoding='utf-8'))
+
+    def encode(self, data: dict, compress: bool) -> bytes:
+        """encode pkg into rabbitmq data"""
+        data = json.dumps(data).encode(encoding='utf-8')
+        if compress:
+            data = zlib.compress(data)
+        data = self.encrypt(data)
+        return data
+
+    async def get_connection(self) -> AbstractRobustConnection:
+        """get rabbitmq connection"""
+        if self._connection is None:
+            self._connection = await aio_pika.connect_robust(
+                host=self._host,
+                port=self._port,
+                login=self._login,
+                password=self._password,
+                heartbeat=self._heartbeat
+            )
+            await self._connection.connect()
+        return self._connection
+
+    async def get_channel(self) -> AbstractRobustChannel:
+        """get rabbitmq channel"""
+        if self._channel is None:
+            connection = await self.get_connection()
+            self._channel = await connection.channel()
+        return self._channel
+
+    async def get_queue(self) -> AbstractRobustQueue:
+        """get rabbitmq queue"""
+        if self._queue is None:
+            channel = await self.get_channel()
+            self._queue = await channel.declare_queue(self.queue)
+        return self._queue
+
+    async def get_exchange(self) -> AbstractExchange:
+        """get rabbitmq default exchange"""
+        if self._exchange is None:
+            channel = await self.get_channel()
+            self._exchange = channel.default_exchange
+        return self._exchange
+
+
+class RabbitMQProducer(AsyncRunnable):
+    """produce data to rabbitmq"""
+
+    _exchange: AbstractExchange
+    _connection: AbstractRobustConnection
+
+    def __init__(self, rabbitmq: RabbitMQ, compress: bool):
+        super().__init__()
+        self._rabbitmq = rabbitmq
+        self._compress = compress
+
+    async def start(self):
+        self._exchange = await self._rabbitmq.get_exchange()
+        while True:
+            await asyncio.sleep(3600)  # sleep forever
+
+    async def publish(self, data: dict):
+        """produce data"""
+        await self._exchange.publish(aio_pika.Message(body=self._rabbitmq.encode(data, self._compress)),
+                                     routing_key=self._rabbitmq.queue)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     aiohttp
     pycryptodomex
     apscheduler
+    aio_pika
 
 [options.packages.find]
 where = .


### PR DESCRIPTION
 add simple RabbitMQ support

kook -> khl.py 生产者 (解析数据) -> RabbitMQ -> khl.py 消费者 (处理数据)

传递过程中 从生产者->消费者端数据为避免明文传输，进行AES加密
```python
from khl import RabbitMQ, Bot, Cert

# 注释项代表有默认值
# Bot 的 compress 参数会影响 RabbitMQ 消息传递中是否压缩

rabbitmq = RabbitMQ(
    # host='127.0.0.1',  # RabbitMQ 服务地址
    # port=5672,  # RabbitMQ 服务端口
    # queue='bot',  # RabbitMQ 队列名称
    # qos=10,   # 速率控制 (该选项控制每次从服务器抓取多少条消息, 控制本地queue内消息数量)
    # heartbeat=30,  # 心跳时间 (RabbitMQ 协议规定每二分之一心跳时间发一次心跳 一般5-60 不推荐小于5)
    login='bot',  # 强制填写 认证信息
    password='password',  # 强制填写 认证信息
    # key='xxxxxx',  # 可由 login+password 生成
    # key_digits=16,  # 密钥位数 16位为AES128 24位为AES192 32位为AES256
    # is_producer=False  # 是否为生产者
)

cert = Cert(
    token='xxx',
    # is_rabbitmq_receiver=True  # 若在 Bot 示例中没有传入 cert, 可由 rabbitmq 参数判断生成
)

---

# 生产者
# 注意 作为生产者时, RabbitMQ 中的 is_producer 为 True
rabbitmq = RabbitMQ(login='bot', password='password', is_producer=True)
bot = Bot('token', rabbitmq=rabbitmq)

# 注意 作为生产者时, cert 中的 is_rabbitmq_receiver 不填 或 False
bot = Bot(
    cert=Cert(token='xxx', verify_token='xxx', encrypt_key='xxx'),
    rabbitmq=rabbitmq
)

---

# 消费者
# 注意 作为消费者时, RabbitMQ 中的 is_producer 不填 或 False
rabbitmq = RabbitMQ(login='bot', password='password')
bot = Bot('token', rabbitmq=rabbitmq)

# 注意 作为消费者时, 若传入 cert, 则 cert 中的 is_rabbitmq_receiver 为 True
bot = Bot(
    cert=Cert(token='xxx', is_rabbitmq_receiver=True),
    rabbitmq=rabbitmq
)

---

# 最后启动
bot.run()
# await bot.start()
```