### PR TITLE
添加消息的引用内容

### DIFF
--- a/khl/message.py
+++ b/khl/message.py
@@ -12,7 +12,7 @@ from ._types import MessageTypes, ChannelPrivacyTypes, EventTypes
 from .user import User, GuildUser
 
 
-class QuoteMessage(Requestable, ABC):
+class QuotedMessage(Requestable, ABC):
     """Basic quote message"""
     _msg_id: str
     _type: int
@@ -43,7 +43,7 @@ class QuoteMessage(Requestable, ABC):
         return self._author
 
 
-class PublicQuoteMessage(QuoteMessage):
+class PublicQuotedMessage(QuotedMessage):
     """quote messages sent in a `PublicTextChannel`"""
 
     def __init__(self, **kwargs):
@@ -56,7 +56,7 @@ class PublicQuoteMessage(QuoteMessage):
         return self._author
 
 
-class PrivateQuoteMessage(QuoteMessage):
+class PrivateQuotedMessage(QuotedMessage):
     """quote messages sent in a `PrivateChannel`"""
     _author: User
 
@@ -128,7 +128,7 @@ class Message(RawMessage, Requestable, ABC):
     """
     _ctx: Context
     _author: User
-    _quote: Optional[QuoteMessage]
+    _quote: Optional[QuotedMessage]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -217,7 +217,7 @@ class PublicMessage(Message):
         self._ctx = Context(channel=channel, guild=guild, _gate_=self.gate)
         self._author = GuildUser(**self.extra['author'], _gate_=self.gate, _lazy_loaded_=True)
         if 'quote' in self.extra:
-            self._quote = PublicQuoteMessage(**self.extra['quote'], _gate_=self.gate, _lazy_loaded_=True)
+            self._quote = PublicQuotedMessage(**self.extra['quote'], _gate_=self.gate, _lazy_loaded_=True)
         else:
             self._quote = None
 
@@ -259,7 +259,7 @@ class PublicMessage(Message):
         return self.extra['mention_here']
 
     @property
-    def quote(self) -> PublicQuoteMessage:
+    def quote(self) -> PublicQuotedMessage:
         """
         get quote of the message
 
@@ -324,7 +324,7 @@ class PrivateMessage(Message):
         return self._channel
 
     @property
-    def quote(self) -> PrivateQuoteMessage:
+    def quote(self) -> PrivateQuotedMessage:
         """
         get quote of the message
 

--- a/khl/message.py
+++ b/khl/message.py
@@ -16,6 +16,7 @@ class QuoteMessage(Requestable, ABC):
     """Basic quote message"""
     _msg_id: str
     _type: int
+    _author: User
     content: str
     create_at: int
 
@@ -28,24 +29,28 @@ class QuoteMessage(Requestable, ABC):
 
     @property
     def id(self):
-        """message's id"""
+        """quote message's id"""
         return self._msg_id
 
     @property
     def type(self):
-        """message's type, refer to MessageTypes for enum detail"""
+        """quote message's type, refer to MessageTypes for enum detail"""
         return MessageTypes(self._type)
+
+    @property
+    def author(self):
+        """quote message author"""
+        return self._author
 
 
 class PublicQuoteMessage(QuoteMessage):
-    _author: GuildUser
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._author = GuildUser(**kwargs.get('author'), _gate_=self.gate, _lazy_loaded_=True)
 
     @property
-    def author(self):
+    def author(self) -> GuildUser:
         """quote message author"""
         return self._author
 
@@ -58,7 +63,7 @@ class PrivateQuoteMessage(QuoteMessage):
         self._author = User(**kwargs.get('author'), _gate_=self.gate, _lazy_loaded_=True)
 
     @property
-    def author(self):
+    def author(self) -> User:
         """quote message author"""
         return self._author
 

--- a/khl/message.py
+++ b/khl/message.py
@@ -44,6 +44,7 @@ class QuoteMessage(Requestable, ABC):
 
 
 class PublicQuoteMessage(QuoteMessage):
+    """quote messages sent in a `PublicTextChannel`"""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -56,6 +57,7 @@ class PublicQuoteMessage(QuoteMessage):
 
 
 class PrivateQuoteMessage(QuoteMessage):
+    """quote messages sent in a `PrivateChannel`"""
     _author: User
 
     def __init__(self, **kwargs):

--- a/khl/message.py
+++ b/khl/message.py
@@ -309,7 +309,7 @@ class PrivateMessage(Message):
         self._ctx = Context(channel=self._channel, _gate_=self.gate)
         self._author = User(**self.extra['author'], _gate_=self.gate, _lazy_loaded_=True)
         if 'quote' in self.extra:
-            self._quote = PublicQuoteMessage(**self.extra['quote'], _gate_=self.gate, _lazy_loaded_=True)
+            self._quote = PrivateQuotedMessage(**self.extra['quote'], _gate_=self.gate, _lazy_loaded_=True)
         else:
             self._quote = None
 


### PR DESCRIPTION
现在可以直接在 `Message` 获取引用内容

```python
# 先判断 quote 是否非 None, None 代表消息不存在引用
if msg.quote:
    # 引用原文的 msg_id
    print(msg.quote.id)
    # 引用原文的内容
    print(msg.quote.content)
    # 引用原文的作者id
    print(msg.quote.author.id)
```