### PR TITLE
feat: add simple RabbitMQ support 

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
-        pip install --upgrade aiohttp pycryptodomex apscheduler
+        pip install --upgrade aiohttp pycryptodomex apscheduler aio_pika
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/khl/bot/bot.py
+++ b/khl/bot/bot.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import Dict, Callable, List, Optional, Union, Coroutine, IO
 
 from .. import AsyncRunnable  # interfaces
-from .. import Cert, HTTPRequester, RateLimiter, Receiver, WebhookReceiver, WebsocketReceiver, Gateway, Client  # net related
+from .. import Cert, HTTPRequester, RateLimiter, Gateway, Client  # net related
+from .. import Receiver, WebhookReceiver, WebsocketReceiver  # net related, receivers
 from .. import MessageTypes, EventTypes, SlowModeTypes, SoftwareTypes  # types
 from .. import User, Channel, PublicChannel, Guild, Event, Message  # concepts
 from ..command import CommandManager

--- a/khl/command/parser.py
+++ b/khl/command/parser.py
@@ -27,8 +27,8 @@ def _get_param_type(param: Union[inspect.Parameter, None]):
     return param.annotation
 
 
-def _wrap_one_param_func(func: Callable) -> Callable:  # pylint: disable=unused-argument
-    def wrapper(msg: Message, client: Client, token: str):  # pylint: disable=unused-argument
+def _wrap_one_param_func(func: Callable) -> Callable:
+    def wrapper(_msg: Message, _client: Client, token: str):
         return func(token)
     return wrapper
 

--- a/khl/command/parser.py
+++ b/khl/command/parser.py
@@ -1,5 +1,4 @@
 """parser: component used in command args handling, convert string token to fit the command signature"""
-import asyncio
 import copy
 import inspect
 import logging
@@ -28,8 +27,8 @@ def _get_param_type(param: Union[inspect.Parameter, None]):
     return param.annotation
 
 
-def _wrap_one_param_func(func: Callable) -> Callable:
-    def wrapper(msg: Message, client: Client, token: str):
+def _wrap_one_param_func(func: Callable) -> Callable:  # pylint: disable=unused-argument
+    def wrapper(msg: Message, client: Client, token: str):  # pylint: disable=unused-argument
         return func(token)
     return wrapper
 

--- a/khl/rabbitmq/__init__.py
+++ b/khl/rabbitmq/__init__.py
@@ -1,0 +1,3 @@
+from .rabbitmq import RabbitMQ
+from .rabbitmq_receiver import RabbitMQReceiver
+from .rabbitmq_producer import RabbitMQProducer, RabbitMQProductionBot

--- a/khl/rabbitmq/rabbitmq.py
+++ b/khl/rabbitmq/rabbitmq.py
@@ -24,7 +24,6 @@ class RabbitMQ:
         self._heartbeat = heartbeat
         self._login = login
         self._password = password
-        self._key = key
         self._key_digits = key_digits
         self.compress = compress
         # check aes is 128, 192 or 256

--- a/khl/rabbitmq/rabbitmq.py
+++ b/khl/rabbitmq/rabbitmq.py
@@ -25,7 +25,6 @@ class RabbitMQ:
         self._heartbeat = heartbeat
         self._login = login
         self._password = password
-        self._key_digits = key_digits
         self.compress = compress
         # check aes is 128, 192 or 256
         if key_digits not in AES.key_size:

--- a/khl/rabbitmq/rabbitmq.py
+++ b/khl/rabbitmq/rabbitmq.py
@@ -44,7 +44,13 @@ class RabbitMQ:
             salt_encoded = b'rabbitmq in khl.py'
 
         # use pbkdf2_hmac to generate key with key_digits
-        self._aes_key = hashlib.pbkdf2_hmac('sha256', key_string.encode('utf-8'), salt_encoded, 100000, dklen=key_digits)
+        self._aes_key = hashlib.pbkdf2_hmac(
+            'sha256',
+            key_string.encode('utf-8'),
+            salt_encoded,
+            100000,
+            dklen=key_digits
+        )
 
     def decrypt(self, data: bytes) -> bytes:
         """ decrypt data

--- a/khl/rabbitmq/rabbitmq.py
+++ b/khl/rabbitmq/rabbitmq.py
@@ -1,0 +1,100 @@
+import hashlib
+import json
+import logging
+import zlib
+import aio_pika
+from Cryptodome.Cipher import AES
+from Cryptodome.Util import Padding
+from aio_pika.abc import AbstractRobustConnection, AbstractRobustChannel, AbstractExchange, AbstractRobustQueue
+log = logging.getLogger(__name__)
+
+
+class RabbitMQ:
+    """rabbitmq configurate/init/connect/encrypt/decrypt/encode/decode"""
+    _connection: AbstractRobustConnection = None
+    _channel: AbstractRobustChannel = None
+    _queue: AbstractRobustQueue = None
+    _exchange: AbstractExchange = None
+    def __init__(self, login: str, password: str, host: str = '127.0.0.1', port: int = 5672, queue: str = 'kook',
+                 qos: int = 10, heartbeat: int = 30, key: str = '', key_digits: int = 16, compress: bool = True):
+        self._host = host
+        self._port = port
+        self.queue = queue
+        self.qos = qos
+        self._heartbeat = heartbeat
+        self._login = login
+        self._password = password
+        self._key = key
+        self._key_digits = key_digits
+        self.compress = compress
+        # check aes is 128, 192 or 256
+        if key_digits not in AES.key_size:
+            raise ValueError(f'rabbitmq key_digits: {key_digits} not in {AES.key_size}')
+        if key != '':
+            key_encoded = key.encode('utf-8').ljust(key_digits, b'\x00')
+        else:
+            # if rabbitmq_key is not defined, use sha256 to generate one
+            key_encoded = hashlib.sha256(f'{login}:{password}'.encode('utf-8')).digest()
+        # make sure key digits is right
+        self._aes_key = key_encoded[:key_digits]
+    def decrypt(self, data: bytes) -> bytes:
+        """ decrypt data
+        :param data: encrypted byte array
+        :return: decrypted byte array
+        """
+        decipher = AES.new(self._aes_key, AES.MODE_CBC, iv=data[:16])
+        data = decipher.decrypt(data[16:])
+        data = Padding.unpad(data, 16)
+        return data
+    def encrypt(self, data: bytes) -> bytes:
+        """ encrypt data
+        :param data: byte array
+        :return: encrypted byte array
+        """
+        data = Padding.pad(data, 16)
+        cipher = AES.new(self._aes_key, AES.MODE_CBC)
+        data = cipher.encrypt(data)
+        return cipher.iv + data
+    def decode(self, data: bytes) -> dict:
+        """decode raw rabbitmq data into plaintext data"""
+        data = self.decrypt(data)
+        if self.compress:
+            data = zlib.decompress(data)
+        return json.loads(str(data, encoding='utf-8'))
+    def encode(self, data: dict) -> bytes:
+        """encode pkg into rabbitmq data"""
+        data = json.dumps(data).encode(encoding='utf-8')
+        if self.compress:
+            data = zlib.compress(data)
+        data = self.encrypt(data)
+        return data
+    async def get_connection(self) -> AbstractRobustConnection:
+        """get rabbitmq connection"""
+        if self._connection is None:
+            self._connection = await aio_pika.connect_robust(
+                host=self._host,
+                port=self._port,
+                login=self._login,
+                password=self._password,
+                heartbeat=self._heartbeat
+            )
+            await self._connection.connect()
+        return self._connection
+    async def get_channel(self) -> AbstractRobustChannel:
+        """get rabbitmq channel"""
+        if self._channel is None:
+            connection = await self.get_connection()
+            self._channel = await connection.channel()
+        return self._channel
+    async def get_queue(self) -> AbstractRobustQueue:
+        """get rabbitmq queue"""
+        if self._queue is None:
+            channel = await self.get_channel()
+            self._queue = await channel.declare_queue(self.queue)
+        return self._queue
+    async def get_exchange(self) -> AbstractExchange:
+        """get rabbitmq default exchange"""
+        if self._exchange is None:
+            channel = await self.get_channel()
+            self._exchange = channel.default_exchange
+        return self._exchange

--- a/khl/rabbitmq/rabbitmq_producer.py
+++ b/khl/rabbitmq/rabbitmq_producer.py
@@ -83,7 +83,7 @@ class RabbitMQProductionBot(AsyncRunnable):
         await asyncio.gather(self.publish_pkg_to_rabbitmq(), self._receiver.start(), self._producer.start())
 
     # keep the usage compatible with Bot interface, so ignored pylint warning
-    # pylint: disable-next=duplicate-code
+    # pylint: disable=duplicate-code
     def run(self):
         """run the rabbitmq bot in blocking mode"""
         if not self.loop:
@@ -92,3 +92,4 @@ class RabbitMQProductionBot(AsyncRunnable):
             self.loop.run_until_complete(self.start())
         except KeyboardInterrupt:
             log.info('see you next time')
+    # pylint: enable=duplicate-code

--- a/khl/rabbitmq/rabbitmq_producer.py
+++ b/khl/rabbitmq/rabbitmq_producer.py
@@ -1,11 +1,9 @@
 import asyncio
 import logging
-from typing import Dict, List
+from typing import Dict
 import aio_pika
 from aio_pika.abc import AbstractExchange, AbstractRobustConnection
 from . import RabbitMQ
-from .._types import MessageTypes
-from ..client import TypeHandler
 from ..cert import Cert
 from ..receiver import WebhookReceiver, WebsocketReceiver
 from ..interface import AsyncRunnable

--- a/khl/rabbitmq/rabbitmq_producer.py
+++ b/khl/rabbitmq/rabbitmq_producer.py
@@ -1,0 +1,94 @@
+import asyncio
+import logging
+from typing import Dict, List
+import aio_pika
+from aio_pika.abc import AbstractExchange, AbstractRobustConnection
+from . import RabbitMQ
+from .._types import MessageTypes
+from ..client import TypeHandler
+from ..cert import Cert
+from ..receiver import WebhookReceiver, WebsocketReceiver
+from ..interface import AsyncRunnable
+log = logging.getLogger(__name__)
+
+class RabbitMQProducer(AsyncRunnable):
+    """produce data to rabbitmq"""
+    _exchange: AbstractExchange
+    _connection: AbstractRobustConnection
+    def __init__(self, rabbitmq: RabbitMQ):
+        super().__init__()
+        self._rabbitmq = rabbitmq
+    async def start(self):
+        self._exchange = await self._rabbitmq.get_exchange()
+        while True:
+            await asyncio.sleep(3600)  # sleep forever
+    async def publish(self, data: dict):
+        """produce data"""
+        await self._exchange.publish(aio_pika.Message(body=self._rabbitmq.encode(data)),
+                                     routing_key=self._rabbitmq.queue)
+
+class RabbitMQProductionBot(AsyncRunnable):
+    """
+    This bot class is made for rabbitmq data production, to send package unwrapped by Receiver to rabbitmq
+    """
+    def __init__(self,
+                 token: str = '',
+                 *,
+                 cert: Cert = None,
+                 compress: bool = True,
+                 port=5000,
+                 route='/khl-wh',
+                 rabbitmq: RabbitMQ = None):
+        """
+        :param cert: used to build requester and receiver
+        :param compress: used to tune the receiver
+        :param port: used to tune the WebhookReceiver
+        :param route: used to tune the WebhookReceiver
+        :param rabbitmq: used to tune the RabbitMQ Receiver or Producer
+        """
+        if not token and not cert:
+            raise ValueError('require token or cert')
+
+        if rabbitmq is None:
+            raise ValueError('require rabbitmq')
+
+        cert = cert or Cert(token=token)
+
+        if cert.type == Cert.Types.WEBSOCKET:
+            receiver = WebsocketReceiver(cert, compress)
+        elif cert.type == Cert.Types.WEBHOOK:
+            receiver = WebhookReceiver(cert, port=port, route=route, compress=compress)
+        else:
+            raise ValueError(f'cert type: {cert.type} not supported')
+
+        self._pkg_queue = asyncio.Queue()
+        self._receiver = receiver
+        self._producer = RabbitMQProducer(rabbitmq)
+
+
+    async def publish_pkg_to_rabbitmq(self):
+        """publish pkg to rabbitmq"""
+        while True:
+            pkg: Dict = await self._pkg_queue.get()
+            log.debug(f'publishing pkg: {pkg}')
+            try:
+                await self._producer.publish(pkg)
+            except Exception as e:
+                log.exception(e)
+            self._pkg_queue.task_done()
+
+    async def start(self):
+        """start the rabbitmq bot"""
+        self._receiver.pkg_queue = self._pkg_queue  # pass the pkg_queue to the receiver
+        await asyncio.gather(self.publish_pkg_to_rabbitmq(), self._receiver.start(), self._producer.start())
+
+    # keep the usage compatible with Bot interface, so ignored pylint warning
+    # pylint: disable-next=duplicate-code
+    def run(self):
+        """run the rabbitmq bot in blocking mode"""
+        if not self.loop:
+            self.loop = asyncio.get_event_loop()
+        try:
+            self.loop.run_until_complete(self.start())
+        except KeyboardInterrupt:
+            log.info('see you next time')

--- a/khl/rabbitmq/rabbitmq_receiver.py
+++ b/khl/rabbitmq/rabbitmq_receiver.py
@@ -1,0 +1,32 @@
+import asyncio
+import logging
+from typing import Dict
+from ..receiver import Receiver
+from .rabbitmq import RabbitMQ
+log = logging.getLogger(__name__)
+
+
+class RabbitMQReceiver(Receiver):
+    """receive data in RabbitMQ mode"""
+    def __init__(self, rabbitmq: RabbitMQ):
+        super().__init__()
+        self._rabbitmq = rabbitmq
+    @property
+    def type(self) -> str:
+        return 'rabbitmq'
+    async def start(self):
+        queue = await self._rabbitmq.get_queue()
+        log.info('[ init ] launched')
+        async with queue.iterator() as queue_iter:
+            async for message in queue_iter:
+                async with message.process():
+                    try:
+                        pkg: Dict = self._rabbitmq.decode(message.body)
+                    except Exception as e:
+                        log.exception(e)
+                        continue
+                    if not pkg:  # empty pkg
+                        continue
+                    while self.pkg_queue.qsize() >= self._rabbitmq.qos:
+                        await asyncio.sleep(0.001)
+                    await self.pkg_queue.put(pkg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     aiohttp
     pycryptodomex
     apscheduler
+    aio_pika
 
 [options.packages.find]
 where = .


### PR DESCRIPTION
不小心把 #216 的分支删了 重新开一个PR
基于 #239 #240 

与源保持高度用法兼容性，不影响以前正在跑的所有代码
只需另加一个生产者，消费者添加rabbitmq参数 即可正常运行
可启动多个消费端处理数据

`pip install -U git+https://github.com/hank9999/khl.py@rabbitmq` 快速安装体验（

kook -> khl.py 生产者 (解析数据) -> RabbitMQ -> khl.py 消费者 (处理数据)
传递过程中 从生产者->消费者端数据为避免明文传输，进行AES加密

AES 密钥采用 PBKDF2 迭代 10万次生成结果，增强安全性
```py
# 注释项代表有默认值
# compress 参数会影响 RabbitMQ 消息传递中是否压缩

rabbitmq = RabbitMQ(
    # host='127.0.0.1',  # RabbitMQ 服务地址
    # port=5672,  # RabbitMQ 服务端口
    # queue='kook',  # RabbitMQ 队列名称
    # qos=10,   # 速率控制 (该选项控制每次从服务器抓取多少条消息, 控制本地queue内消息数量)
    # heartbeat=30,  # 心跳时间 (RabbitMQ 协议规定每二分之一心跳时间发一次心跳 一般5-60 不推荐小于5)
    login='bot',  # 强制填写 认证信息
    password='password',  # 强制填写 认证信息
    # key='',  # 可自定义高强度 key, 建议自定义大于16位, 不填由 login+password+queue+compress+key_digits 生成
    # salt='',  # 用于 PBKDF2 算法迭代密钥, 建议自定义大于16位, 不填使用默认值
    # key_digits=32,  # 密钥位数 16位为AES128 24位为AES192 32位为AES256 不填默认32位 （密钥字节数）
    # compress=True  # 是否压缩数据
)
```

```py
# 生产者
from khl.rabbitmq import RabbitMQProductionBot, RabbitMQ
rabbitmq = RabbitMQ(login='bot', password='password')

# 使用 rabbitmq 模块下的 RabbitMQProductionBot 替代 Bot 接收数据
# Cert Webhook 等与 Bot 保持一致
# 无 client, gate, out 选项, 这个对象只用于接收数据，不需要有HTTP请求/解析的功能
# 无 task 任务 如需任务需要在消费端添加
bot = RabbitMQProductionBot('token', rabbitmq=rabbitmq) 

# 与 Bot 启动方法保持兼容性
# bot.start()
bot.run()
```

```py
# 消费者
from khl import Bot
from khl.rabbitmq import RabbitMQ, RabbitMQReceiver
rabbitmq = RabbitMQ(login='bot', password='password')

# 借助 PR #240, 使用自定义 Receiver 直接传入，无需修改任何原有逻辑
bot = Bot('token', receiver=RabbitMQReceiver(rabbitmq))

bot.run()
```