### PR TITLE
feat(card): add invisible theme

### DIFF
--- a/khl/card/interface.py
+++ b/khl/card/interface.py
@@ -41,6 +41,7 @@ class Types:
         WARNING = 'warning'
         INFO = 'info'
         NONE = 'none'
+        INVISIBLE = 'invisible'
 
     class Size(_TypeEnum):
         """describes a component's size"""


### PR DESCRIPTION
## Summary

Add `Types.Theme.INVISIBLE` with the value `invisible` so card messages can use KOOK's invisible card theme through the SDK instead of failing enum validation.

## Test

```python
import json
from khl.card import Card, CardMessage, Types

card = Card(theme='invisible')
payload = json.loads(json.dumps(CardMessage(card), ensure_ascii=False))
assert Types.Theme.INVISIBLE.value == 'invisible'
assert payload[0]['theme'] == 'invisible'
```