### PR TITLE
Fix Bot.run startup on Python 3.14 when no current event loop exists

### DIFF
--- a/khl/bot/bot.py
+++ b/khl/bot/bot.py
@@ -488,7 +488,11 @@ class Bot(AsyncRunnable):
     def run(self):
         """run the bot in blocking mode"""
         if not self.loop:
-            self.loop = asyncio.get_event_loop()
+            try:
+                self.loop = asyncio.get_event_loop()
+            except RuntimeError:
+                self.loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self.loop)
         try:
             self.loop.run_until_complete(self.start())
         except KeyboardInterrupt:


### PR DESCRIPTION
On Python 3.14, `asyncio.get_event_loop()` raises `RuntimeError` when no
current event loop exists in the main thread. `Bot.run()` calls it at startup
and crashes immediately.

This change keeps the existing code path on older Python versions and only
creates/sets a new event loop when `get_event_loop()` fails.

**Before**
bot.run() → RuntimeError before reaching start()

**After**
bot.run() → proceeds past loop init → reaches start()